### PR TITLE
Improved handling of scoped column names

### DIFF
--- a/lib/active_record/union_relation.rb
+++ b/lib/active_record/union_relation.rb
@@ -53,7 +53,9 @@ module ActiveRecord
       end
 
       def to_mapping(columns)
-        [model_name, columns.zip(sources).to_h]
+        # Remove the scope_name/table_name when using table_name.column
+        sources_without_scope = sources.map { _1.split('.').last }
+        [model_name, columns.zip(sources_without_scope).to_h]
       end
 
       private


### PR DESCRIPTION
When incorporating joins in unioned queries, it is often necessary to specify a table or scope name as the column name to resolve column ambiguity.

In the example below, using "comments.id" is essential due to the ambiguity introduced by the join. (This example is based on the structure in the test.)

```ruby
relation = ActiveRecord.union(:id, :post_id) do |union|
  comments = Comment.joins(:post).where(posts: { published: true })
  posts = Post.none

  union.add comments, "comments.id", "comments.post_id"
  union.add posts, nil, "posts.id"
end

first_comment = relation.first 
```

Attempting to access the attributes of the results yields unexpected results:

```ruby
first_comment.post_id # => missing attribute 'post_id' for Comment
```

The populated attributes include the table/scope name:

```ruby
first_comment.attributes_names # => ["comments.id", "comments.post_id"]
```

During the record filling via the mappings, the created attribute names are "comments.id" and "comments.post_id" instead of "id" and "post_id".

This pull request proposes a simple (though not perfect) solution for this issue. It essentially splits the column mapping name on the '.' and takes the last part.

 







