### PR TITLE
Resolve STI discriminator values lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- Resolve STI discriminator values lazily, so subclasses that are autoloaded after the union is built still instantiate, and rows whose type column contains the base class name instantiate as the base class.
+
 ## [0.4.0] - 2025-01-04
 
 ### Added

--- a/lib/active_record/union_relation.rb
+++ b/lib/active_record/union_relation.rb
@@ -59,6 +59,10 @@ module ActiveRecord
           yield name
         end
 
+        def matches?(name)
+          name == self.name
+        end
+
         def to_sql
           Arel.sql("'#{name}'")
         end
@@ -68,15 +72,26 @@ module ActiveRecord
       # case we use the inheritance column as the discriminator and need to
       # include all of the subclasses in the mappings hash.
       class MultiModelName
-        attr_reader :inheritance_column, :names
+        attr_reader :inheritance_column, :model
 
-        def initialize(inheritance_column, names)
+        def initialize(inheritance_column, model)
           @inheritance_column = inheritance_column
-          @names = names
+          @model = model
         end
 
-        def each_name(&block)
-          names.each(&block)
+        def each_name
+          [model, *model.descendants].each { |klass| yield klass.name }
+        end
+
+        def matches?(name)
+          klass =
+            begin
+              name.constantize
+            rescue NameError
+              nil
+            end
+
+          !klass.nil? && klass <= model
         end
 
         def to_sql
@@ -94,7 +109,7 @@ module ActiveRecord
           if model._has_attribute?(model.inheritance_column)
             MultiModelName.new(
               quote_column_name(model.inheritance_column),
-              model.descendants.map(&:name)
+              model
             )
           else
             SingleModelName.new(model.name)
@@ -115,10 +130,17 @@ module ActiveRecord
       end
 
       def merge_mappings(mappings, columns)
-        # Remove the scope_name/table_name when using table_name.column
-        mapping =
-          columns.zip(sources.map { |source| source.split(".").last }).to_h
+        mapping = mapping_for(columns)
         model_name.each_name { |name| mappings[name] = mapping }
+      end
+
+      def mapping_for(columns)
+        # Remove the scope_name/table_name when using table_name.column
+        columns.zip(sources.map { |source| source.split(".").last }).to_h
+      end
+
+      def matches?(name)
+        model_name.matches?(name)
       end
 
       private
@@ -161,6 +183,23 @@ module ActiveRecord
 
       mappings = {}
       subqueries.each { |subquery| subquery.merge_mappings(mappings, columns) }
+
+      # Descendants of a model using single-table inheritance are snapshotted
+      # into the mappings when the union is built, but with lazy autoloading
+      # some subclasses may not be loaded yet at that point. Resolve unknown
+      # discriminator values on first use instead of failing to instantiate
+      # the row. The last matching subquery wins, mirroring the merge order of
+      # the eagerly registered names above.
+      subqueries = self.subqueries
+      mappings.default_proc = ->(hash, name) do
+        subquery =
+          name &&
+            subqueries.reverse_each.detect do |candidate|
+              candidate.matches?(name)
+            end
+
+        hash[name] = subquery.mapping_for(columns) if subquery
+      end
 
       Class.new(model) do
         # Set the inheritance column and register the discriminator as a string

--- a/test/active_record/union_relation_test.rb
+++ b/test/active_record/union_relation_test.rb
@@ -95,5 +95,34 @@ module ActiveRecord
 
       assert unioned.keys.all? { |key| key < Link }
     end
+
+    def test_sti_subclass_defined_after_union_is_built
+      relation =
+        ActiveRecord.union(:id, :url) { |union| union.add Link.all, :id, :url }
+
+      Object.const_set(:PodcastLink, Class.new(Link))
+      PodcastLink.create!(url: "http://example.com/some-podcast")
+
+      podcast =
+        relation.detect { |link| link.url == "http://example.com/some-podcast" }
+
+      assert_instance_of PodcastLink, podcast
+    ensure
+      PodcastLink.delete_all
+      Object.send(:remove_const, :PodcastLink)
+    end
+
+    def test_sti_rows_with_base_class_type
+      Link.create!(type: "Link", url: "http://example.com/some-base")
+
+      relation =
+        ActiveRecord.union(:id, :url) { |union| union.add Link.all, :id, :url }
+
+      base =
+        relation.detect { |link| link.url == "http://example.com/some-base" }
+      assert_instance_of Link, base
+    ensure
+      Link.where(url: "http://example.com/some-base").delete_all
+    end
   end
 end


### PR DESCRIPTION
When a union includes a relation on an STI model, `Subquery#initialize` snapshots `model.descendants.map(&:name)` into the mappings hash. With lazy autoloading (Rails development, and test unless eager loading is enabled), a subclass that hasn't been referenced yet is missing from the snapshot, and any row of that type fails to instantiate with `NoMethodError: undefined method '[]' for nil`. Applications work around this by eager loading the entire STI hierarchy at boot.

This registers the base model instead of a name snapshot and gives the mappings hash a `default_proc`: an unknown discriminator value is constantized on first use and reuses the mapping of the last matching STI subquery, mirroring the merge order of the eagerly registered names. As a side effect, rows whose type column contains the base class name itself also instantiate now — `descendants` never includes the base class, so those raised the same error even with every subclass loaded.
